### PR TITLE
Fix: broken URL for starterpacks.net

### DIFF
--- a/src/tools.json
+++ b/src/tools.json
@@ -313,7 +313,7 @@
   },
   {
     "name": "Starter Packs",
-    "url": "https://wwww.starterpacks.net",
+    "url": "https://www.starterpacks.net",
     "description": "A platform to explore and discover Bluesky starter packs and profiles.",
     "screenshotPath": "assets/screenshots/tools/starter-packs.webp",
     "categories": ["Starter Packs"]


### PR DESCRIPTION
Not mine, but someone reported and I verified https://bsky.app/profile/loveree.bsky.social/post/3ll5fl4k6z22i